### PR TITLE
Add last-modified timestamp into the metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web"
-version = "8.0.0"
+version = "8.1.0"
 description = "Rust Macro which embeds files into your executable. A fork of `rust-embed` with a focus on usage on web servers."
 readme = "readme.md"
 documentation = "https://docs.rs/rust-embed"
@@ -22,8 +22,8 @@ required-features = ["include-exclude"]
 
 [dependencies]
 walkdir = "2.3.1"
-rust-embed-for-web-impl = { version = "8.0.0", path = "impl"}
-rust-embed-for-web-utils = { version = "9.0.0", path = "utils"}
+rust-embed-for-web-impl = { version = "8.1.0", path = "impl"}
+rust-embed-for-web-utils = { version = "9.1.0", path = "utils"}
 
 [dev-dependencies]
 chrono = "0.4"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-embed-for-web-impl"
 description = "The proc-macro implementation of rust-embed-for-web."
-version = "8.0.0"
+version = "8.1.0"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"
 license = "MIT"
@@ -13,7 +13,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-rust-embed-for-web-utils = { version = "9.0.0", path = "../utils"}
+rust-embed-for-web-utils = { version = "9.1.0", path = "../utils"}
 
 syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
 quote = "1"

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -98,6 +98,10 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
         Some(last_modified) => quote! { Some(#last_modified) },
         None => quote! { None },
     };
+    let last_modified_timestamp = match file.metadata.last_modified_timestamp() {
+        Some(last_modified) => quote! { Some(#last_modified) },
+        None => quote! { None },
+    };
     let mime_type = match file.metadata.mime_type() {
         Some(mime_type) => quote! { Some(#mime_type ) },
         None => quote! { None },
@@ -141,7 +145,7 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
             Some(rust_embed_for_web::EmbeddedFile {
                 data: &data,
                 data_gzip: #data_gzip_value_embed,
-                metadata: rust_embed_for_web::Metadata::__rust_embed_for_web_new(#hash, #etag, #last_modified, #mime_type)
+                metadata: rust_embed_for_web::Metadata::__rust_embed_for_web_new(#hash, #etag, #last_modified, #last_modified_timestamp, #mime_type)
             })
         }
     }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web-utils"
-version = "9.0.0"
+version = "9.1.0"
 description = "Utilities for rust-embed-for-web"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"


### PR DESCRIPTION
Otherwise, the only way to get the last modified timestamp is parsing it back from the formatted string which is a bit silly.