### PR TITLE
Implement `prefix` attribute support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web"
-version = "11.1.4"
+version = "11.2.0"
 description = "Rust Macro which embeds files into your executable. A fork of `rust-embed` with a focus on usage on web servers."
 readme = "README.md"
 documentation = "https://docs.rs/rust-embed-for-web"
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 walkdir = "2.4.0"
-rust-embed-for-web-impl = { version = "11.1.4", path = "impl" }
-rust-embed-for-web-utils = { version = "11.1.4", path = "utils" }
+rust-embed-for-web-impl = { version = "11.2.0", path = "impl" }
+rust-embed-for-web-utils = { version = "11.2.0", path = "utils" }
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-embed-for-web-impl"
 description = "The proc-macro implementation of rust-embed-for-web."
-version = "11.1.4"
+version = "11.2.0"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"
 license = "MIT"

--- a/impl/src/dynamic.rs
+++ b/impl/src/dynamic.rs
@@ -72,6 +72,7 @@ pub(crate) fn generate_dynamic_impl(
     ident: &syn::Ident,
     config: &Config,
     folder_path: &str,
+    prefix: &str,
 ) -> TokenStream2 {
     let config = config.make_embed();
 
@@ -79,6 +80,9 @@ pub(crate) fn generate_dynamic_impl(
       impl #ident {
         fn get(path: &str) -> Option<rust_embed_for_web::DynamicFile> {
           let config = { #config };
+          let Some(path) = path.strip_prefix(#prefix) else {
+            return None;
+          };
           if config.should_include(path) {
             let folder_path: std::path::PathBuf = std::convert::From::from(#folder_path);
             let combined_path = folder_path.join(path);

--- a/impl/src/embed.rs
+++ b/impl/src/embed.rs
@@ -97,8 +97,9 @@ pub(crate) fn generate_embed_impl(
     ident: &syn::Ident,
     config: &Config,
     folder_path: &str,
+    prefix: &str,
 ) -> TokenStream2 {
-    let embeds: Vec<TokenStream2> = get_files(folder_path, config)
+    let embeds: Vec<TokenStream2> = get_files(folder_path, config, prefix)
         .filter_map(
             |FileEntry {
                  rel_path,

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -71,10 +71,19 @@ fn impl_rust_embed_for_web(ast: &syn::DeriveInput) -> TokenStream2 {
 
     let config = read_attribute_config(ast);
 
-    if cfg!(debug_assertions) && !cfg!(feature = "always-embed") {
-        generate_dynamic_impl(&ast.ident, &config, &folder_path)
+    let prefixes = find_attribute_values(ast, "prefix");
+    let prefix = if prefixes.len() == 0 {
+        "".to_string()
+    } else if prefixes.len() == 1 {
+        prefixes[0].clone()
     } else {
-        generate_embed_impl(&ast.ident, &config, &folder_path)
+        panic!("#[derive(RustEmbed)] must have at most one prefix, you supplied several");
+    };
+
+    if cfg!(debug_assertions) && !cfg!(feature = "always-embed") {
+        generate_dynamic_impl(&ast.ident, &config, &folder_path, &prefix)
+    } else {
+        generate_embed_impl(&ast.ident, &config, &folder_path, &prefix)
     }
 }
 

--- a/tests/prefix.rs
+++ b/tests/prefix.rs
@@ -1,0 +1,12 @@
+use rust_embed_for_web::{RustEmbed, EmbedableFile};
+
+#[derive(RustEmbed)]
+#[folder = "examples/public"]
+#[prefix = "foo/bar/"]
+struct Embed;
+
+#[test]
+fn prefix_works() {
+    assert!(Embed::get("index.html").is_none());
+    assert!(Embed::get("foo/bar/index.html").is_some());
+}

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web-utils"
-version = "11.1.4"
+version = "11.2.0"
 description = "Utilities for rust-embed-for-web"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -18,6 +18,7 @@ pub struct FileEntry {
 pub fn get_files<'t>(
     folder_path: &'t str,
     config: &'t Config,
+    prefix: &'t str,
 ) -> impl Iterator<Item = FileEntry> + 't {
     walkdir::WalkDir::new(folder_path)
         .follow_links(true)
@@ -26,6 +27,7 @@ pub fn get_files<'t>(
         .filter(|e| e.file_type().is_file())
         .filter_map(move |e| {
             let rel_path = path_to_str(e.path().strip_prefix(folder_path).unwrap());
+            let rel_path = format!("{}{}", prefix, rel_path);
             let full_canonical_path =
                 path_to_str(std::fs::canonicalize(e.path()).expect("Could not get canonical path"));
 


### PR DESCRIPTION
This implements the `prefix` attribute, and resolves issue #10.

I added a basic test file at `tests/prefix.rs`. I also tested manually in a real project.
 
This also bumps the version to `11.2.0` in a separate commit, which I supposed was the correct version choice, but I'm not sure.