### PR TITLE
fix: cargo clippy for CI

### DIFF
--- a/impl/src/compress.rs
+++ b/impl/src/compress.rs
@@ -7,7 +7,7 @@ use flate2::{write::GzEncoder, Compression};
 /// the uncompressed version.
 const COMPRESSION_INCLUDE_THRESHOLD: f64 = 0.95;
 
-pub(crate) fn compress_gzip(data: &Vec<u8>) -> Option<Vec<u8>> {
+pub(crate) fn compress_gzip(data: &[u8]) -> Option<Vec<u8>> {
     let mut data_gzip: Vec<u8> = Vec::new();
     let mut encoder = GzEncoder::new(&mut data_gzip, Compression::default());
     encoder
@@ -24,8 +24,8 @@ pub(crate) fn compress_gzip(data: &Vec<u8>) -> Option<Vec<u8>> {
     }
 }
 
-pub(crate) fn compress_br(data: &Vec<u8>) -> Option<Vec<u8>> {
-    let mut data_read = BufReader::new(&data[..]);
+pub(crate) fn compress_br(data: &[u8]) -> Option<Vec<u8>> {
+    let mut data_read = BufReader::new(data);
     let mut data_br: Vec<u8> = Vec::new();
     brotli::BrotliCompress(
         &mut data_read,

--- a/impl/src/dynamic.rs
+++ b/impl/src/dynamic.rs
@@ -80,9 +80,7 @@ pub(crate) fn generate_dynamic_impl(
       impl #ident {
         fn get(path: &str) -> Option<rust_embed_for_web::DynamicFile> {
           let config = { #config };
-          let Some(path) = path.strip_prefix(#prefix) else {
-            return None;
-          };
+          let path = path.strip_prefix(#prefix)?;
           if config.should_include(path) {
             let folder_path: std::path::PathBuf = std::convert::From::from(#folder_path);
             let combined_path = folder_path.join(path);


### PR DESCRIPTION
In my CI it reports an warning then caused the CI failed:

```
warning: this `let...else` may be rewritten with the `?` operator
  --> src/handler/http/router/ui.rs:22:10
   |
22 | #[derive(RustEmbed)]
   |          ^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `#[warn(clippy::question_mark)]` on by default
   = note: this warning originates in the derive macro `RustEmbed` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR fixed the `cargo clippy` issues.