### PR TITLE
Update brotli dependency and bump version to 11.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web"
-version = "11.2.1"
+version = "11.3.0"
 description = "Rust Macro which embeds files into your executable. A fork of `rust-embed` with a focus on usage on web servers."
 readme = "README.md"
 documentation = "https://docs.rs/rust-embed-for-web"
@@ -12,13 +12,13 @@ edition = "2018"
 
 [dependencies]
 walkdir = "2.4.0"
-rust-embed-for-web-impl = { version = "11.2.1", path = "impl" }
-rust-embed-for-web-utils = { version = "11.2.1", path = "utils" }
+rust-embed-for-web-impl = { version = "11.3.0", path = "impl" }
+rust-embed-for-web-utils = { version = "11.3.0", path = "utils" }
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }
 flate2 = "1.0"
-brotli = "6.0"
+brotli = "8.0"
 zstd = "0.13"
 actix-web = "4.4"
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-embed-for-web-impl"
 description = "The proc-macro implementation of rust-embed-for-web."
-version = "11.2.1"
+version = "11.3.0"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"
 license = "MIT"
@@ -13,7 +13,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-rust-embed-for-web-utils = { version = "11.1.4", path = "../utils" }
+rust-embed-for-web-utils = { version = "11.3.0", path = "../utils" }
 
 syn = { version = "2.0", default-features = false, features = [
   "derive",
@@ -26,7 +26,7 @@ walkdir = "2.4.0"
 
 # Compression
 flate2 = "1.0"
-brotli = "6.0"
+brotli = "8.0"
 zstd = { version = "0.13", optional = true }
 
 globset = { version = "0.4", optional = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-for-web-utils"
-version = "11.2.1"
+version = "11.3.0"
 description = "Utilities for rust-embed-for-web"
 readme = "readme.md"
 repository = "https://github.com/SeriousBug/rust-embed-for-web"


### PR DESCRIPTION
## Summary
- Updated `brotli` dependency from 6.0 to 8.0.2 in both root and `impl` crates
- Bumped package version to 11.3.0 across all workspace crates
- All tests pass, including brotli compression roundtrip tests

This release includes:
- The recently merged zstd compression support (#18)
- Updated brotli dependency (major version update from 6.0 to 8.0.2)

## Test plan
- [x] Run full test suite with `cargo test`
- [x] Run compression-specific tests with features enabled
- [x] Verify brotli compression roundtrip test passes
- [x] Verify build succeeds with new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)